### PR TITLE
Fix misc bugs and TS issues

### DIFF
--- a/src/Browser/Content.ts
+++ b/src/Browser/Content.ts
@@ -2,18 +2,18 @@ import browser from 'webextension-polyfill'
 
 const messageHandler = (event: MessageEvent) => {
   // Only accept messages from same frame
-  if (event.source !== globalThis) return
+  if (event.source !== (globalThis as unknown as Window)) return
 
   // Only accept messages that we know are ours
   if (event.data.source !== 'meteor-devtools-evolved') return
 
   browser.runtime.sendMessage(event.data).catch(() => {
     // Cleans up and prevent "context invalidated" errors.
-    window.removeEventListener('message', messageHandler)
+    globalThis.removeEventListener('message', messageHandler)
   })
 }
 
-window.addEventListener('message', messageHandler)
+globalThis.addEventListener('message', messageHandler)
 
 const url = browser.runtime.getURL('/dist/inject.js')
 const script = document.createElement('script')

--- a/src/Injectors/MinimongoInjector.ts
+++ b/src/Injectors/MinimongoInjector.ts
@@ -19,20 +19,21 @@ const cleanup = (object: any) => {
 
   for (const key of Object.keys(clonedObject)) {
     if (!clonedObject[key]) {
-      return
+      // Falsy primitive value (null, 0, false, '') — leave as-is and keep going.
+      continue
     }
 
     if (typeof clonedObject[key] === 'object') {
       if (isArray(clonedObject[key])) {
         clonedObject[key] = clonedObject[key].map((item: any) => cleanup(item))
-        return
+        continue
       }
 
       if (clonedObject[key] instanceof Date) {
         clonedObject[key] = `[Object::${
           clonedObject[key].constructor.name
         }] ${clonedObject[key].toISOString()}`
-        return
+        continue
       }
 
       if (clonedObject[key].constructor.name !== 'Object') {
@@ -40,11 +41,10 @@ const cleanup = (object: any) => {
           clonedObject[key] = `[Object::${
             clonedObject[key].constructor.name
           }] ${clonedObject[key].toString()}`
-          return
         } else {
           clonedObject[key] = `[Object::${clonedObject[key].constructor.name}]`
-          return
         }
+        continue
       }
 
       clonedObject[key] = cleanup(clonedObject[key])
@@ -73,7 +73,7 @@ const getCollections = () => {
   const data = Object.fromEntries(
     Object.values(collections).map((collection: any) => [
       collection.name,
-      [...getDocs(collection)].map(item => cleanup(item)),
+      [...getDocs(collection)].map(item => cleanup(item)).filter(Boolean),
     ]),
   )
 

--- a/src/Pages/Panel/DDP/FilterConstants.ts
+++ b/src/Pages/Panel/DDP/FilterConstants.ts
@@ -12,7 +12,7 @@ export const FilterCriteriaMap: {
   Object.entries(FilterCriteria).flatMap(([key, matchers]) =>
     matchers.map(matcher => [matcher, key]),
   ),
-)
+) as { [key: string]: FilterType }
 
 export const detectType = (content?: DDPLogContent) => {
   if (content && content.msg && content.msg in FilterCriteriaMap) {

--- a/src/Pages/Panel/Minimongo/MinimongoContainer.tsx
+++ b/src/Pages/Panel/Minimongo/MinimongoContainer.tsx
@@ -29,6 +29,10 @@ export const MinimongoContainer: FunctionComponent<Props> = observer(
       ({ data, index, style }: IRow) => {
         const item = data.items![index]
 
+        if (!item?.document) {
+          return null
+        }
+
         return (
           <MinimongoRow
             style={style}

--- a/src/Pages/Panel/Navigation.tsx
+++ b/src/Pages/Panel/Navigation.tsx
@@ -85,7 +85,7 @@ export const Navigation: FunctionComponent = observer(() => {
       icon: 'issue',
       content: <strong>Issues</strong>,
       handler: () => {
-        openTab([...repositoryData.html_url, '/issues'])
+        openTab(repositoryData.html_url + '/issues')
         analytics?.event('navigation', 'click', { label: 'feedback' })
       },
       shine: true,
@@ -106,7 +106,7 @@ export const Navigation: FunctionComponent = observer(() => {
       ),
       shine: true,
       handler: () => {
-        openTab([...repositoryData.html_url, '/stargazers'])
+        openTab(repositoryData.html_url + '/stargazers')
 
         analytics?.event('navigation', 'click', { label: 'star' })
       },

--- a/src/Stores/Panel/MinimongoStore/index.ts
+++ b/src/Stores/Panel/MinimongoStore/index.ts
@@ -89,9 +89,9 @@ export class MinimongoStore {
   @action
   setCollections(collections: RawCollections) {
     this.collections = mapValues(collections, (collection, collectionName) => {
-      return collection.map(document =>
-        MinimongoStore.wrapDocument(document, collectionName),
-      )
+      return collection
+        .filter(doc => doc != null)
+        .map(document => MinimongoStore.wrapDocument(document, collectionName))
     })
 
     this.computeCollectionSizes()
@@ -121,8 +121,6 @@ export class MinimongoStore {
     collectionName: string,
   ): IDocumentWrapper {
     const _string = JSONUtils.stringify(document)
-
-    console.log({ collectionName })
 
     return {
       collectionName,

--- a/src/Utils/StringUtils.ts
+++ b/src/Utils/StringUtils.ts
@@ -6,9 +6,7 @@ export namespace StringUtils {
   export const classPrefix = 'mde'
 
   export const truncate = (str: string, max: number = 40) => {
-    return isString(str) && str.length > max
-      ? [...str.slice(0, max), '...']
-      : str
+    return isString(str) && str.length > max ? str.slice(0, max) + '...' : str
   }
 
   /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,12 @@
 declare module '*.gif'
 declare module '*.png'
 
+// structuredClone is available in page context at runtime but not typed until TS 4.7.
+declare function structuredClone<T>(
+  value: T,
+  options?: { transfer?: Transferable[] },
+): T
+
 type MeteorID = string
 
 interface Window {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "strict": false,
     "noImplicitAny": false,
     "target": "ES6",
+    "lib": ["esnext", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
     "experimentalDecorators": true,


### PR DESCRIPTION
While working on iframe support and SubsManager compatibility (coming in a separate PR), I needed the extension to actually run cleanly first. These are the bugs I hit along the way.

### Fixes

**`StringUtils.truncate` returned a character array instead of a string**
`[...str.slice(0, max), '...']` spreads the string into individual characters. In template literals this rendered as `H,e,l,l,o,...`. Fixed to `str.slice(0, max) + '...'`.

**Navigation links opened broken URLs**
Same spread bug — `openTab([...url, '/issues'])` passed an array of characters to `browser.tabs.create`, so the Issues and Star links silently did nothing. Fixed to string concatenation.

**Minimongo tab crashed with `Cannot read properties of null (reading '_id')`**
`cleanup()` in `MinimongoInjector` used `return` inside a `for...of` loop where `continue` was needed. On any falsy field value (`null`, `0`, `false`, `""`), the function exited early and returned `undefined` for an otherwise valid document. Those `undefined` values reached the React virtualised list renderer, which then crashed trying to read `._id` on null. Fixed at three layers: `return` → `continue` in the loop, `.filter(Boolean)` after `cleanup()`, and a null guard in the row renderer as a safety net.

**`FilterConstants` TypeScript type inference error**
`Object.fromEntries(flatMap(...))` return type wasn't inferred correctly, causing a downstream TS error. Added explicit cast.

**`Content.ts` message source check consistency**
Minor fix in the content script message handler.

**`structuredClone` not typed (`MinimongoInjector`)**
`MinimongoInjector` calls `structuredClone`, which is available at runtime but untyped in the configured TS libs. Added `"lib": ["esnext", "dom"]` to `tsconfig.json` for the extension bundle; added an ambient declaration in `index.d.ts` for the injected page-context script where tsconfig libs don't apply.